### PR TITLE
Bump PPI and fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,4 @@ perl:
     - "5.22"
 
 before_install:
-    - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
-    - source ~/travis-perl-helpers/init --auto
-
-install:
-    - cpanm --quiet --installdeps --notest .
-    - cpanm --quiet --notest Devel::Cover::Report::Coveralls
-
-script:
-    - cover -delete && cover -test
-
-after_success:
-    - cover -report coveralls
+    - COVERAGE=1 eval $(curl https://travis-perl.github.io/init) --auto

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,7 +65,7 @@ my %WriteMakefile = (
 		},
 
 	'PREREQ_PM'     => {
-		'PPI' => '1.126'
+		'PPI' => '1.236'
 		},
 
 	'META_MERGE' => {


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/november.html).

This bumps `PPI` to the latest version, and fixes the `.travis.yml` to successfully build even on Perl 5.8.